### PR TITLE
fix: use hardcoded branch name in workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: $default-branch
+        default: master
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || $default-branch }}
+      branch: ${{ github.event.inputs.branch || master }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""


### PR DESCRIPTION
Attempted to use `$default-branch` variable but it didn't work, see https://github.com/openedx/AudioXBlock/actions/runs/3083687380

This just hard-codes the name of the default branch in this repo.