### PR TITLE
fix: Uncommented parameters in upgrade requirements workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,7 +17,7 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'master' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
-      eam_reviewers: "arbi-bom"
+      team_reviewers: "arbi-bom"
       email_address: "arbi-bom@edx.org"
       send_success_notification: false
     secrets:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,9 +17,9 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'master' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
-      # team_reviewers: ""
-      # email_address: ""
-      # send_success_notification: false
+      eam_reviewers: "arbi-bom"
+      email_address: "arbi-bom@edx.org"
+      send_success_notification: false
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
       requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
**Description**
- Uncommented required parameters (`team_reviewers` and `email_address` ) for reusable upgrade requirements workflow