### PR TITLE
fix: remove deprecated xblock.fragment import

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -4,7 +4,11 @@
 import pkg_resources
 from xblock.core import XBlock
 from xblock.fields import Integer, Scope, String
-from xblock.fragment import Fragment
+try:
+    from web_fragments.fragment import Fragment
+except: 
+    # for backwards compatibility with quince and prior releases
+    from xblock.fragment import Fragment
 try:
     from xblock.utils.resources import ResourceLoader
 except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ def is_requirement(line):
 
 setup(
     name='audio-xblock',
-    version='0.3.0',
+    version='0.3.1',
     description='Audio XBlock, to play audio files in the course',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description
- This replace `xblock.fragment` with `web_fragments.fragment`. `xblock.fragment` was [removed as of 2024-02-26](https://docs.openedx.org/projects/xblock/en/latest/changelog.html#id2). If this xblock is used in a course, the entire course will fail to load.
